### PR TITLE
Fix Heroku deploy button

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ You can try it by hosting on your own or deploy to Heroku with a button click.
 Deploy To Heroku:
 
 .. image:: https://www.herokucdn.com/deploy/button.svg
-   :target: https://heroku.com/deploy?template=https://github.com/ntbrown/django-simple-forum/
+   :target: https://heroku.com/deploy?template=https://github.com/MicroPyramid/django-simple-forum/
 
 
 We are always looking to help you customize the whole or part of the code as you like.

--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ You can try it by hosting on your own or deploy to Heroku with a button click.
 Deploy To Heroku:
 
 .. image:: https://www.herokucdn.com/deploy/button.svg
-   :target: https://heroku.com/deploy?template=https://github.com/MicroPyramid/django-simple-forum
+   :target: https://heroku.com/deploy?template=https://github.com/ntbrown/django-simple-forum/
 
 
 We are always looking to help you customize the whole or part of the code as you like.

--- a/sandbox/requirements.txt
+++ b/sandbox/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.6.0
 whitenoise==3.1
 dj-database-url==0.4.1
-psycopg2==2.6.1
+psycopg2==2.7


### PR DESCRIPTION
Known bug in psycopg 2.6 causing the postgres error noted in the open issues.
This is fixed in version 2.7 hence the updated requirements. Deploy has been tested successfully.