### PR TITLE
pycops version to fix heroku deploy error

### DIFF
--- a/sandbox/requirements.txt
+++ b/sandbox/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.6.0
 whitenoise==3.1
 dj-database-url==0.4.1
-psycopg2==2.7
+psycopg2


### PR DESCRIPTION
psycopg2 was failing on heroku